### PR TITLE
Rename groupId to 'ome'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.openmicroscopy</groupId>
+  <groupId>ome</groupId>
   <artifactId>ome-turbojpeg</artifactId>
   <version>0.1.0-SNAPSHOT</version>
 


### PR DESCRIPTION
Changing the `groupId` should permit release and upload to the OME artifactory.  The `distributionManagement` section all looks correct, so I don't think any further tweaks are needed before release.